### PR TITLE
feat: support to hostname includes dots

### DIFF
--- a/graphite_mapping.conf
+++ b/graphite_mapping.conf
@@ -4,21 +4,24 @@ mappings:
 # memory mapping
 ################################################
 
-- match: "truenas.*.system.ram.*"
+- match: 'truenas\.(.*)\.system\.ram\.(.*)'
+  match_type: "regex"
   name: "physical_memory"
   labels:
     job: "truenas"
     instance: "${1}"
     kind: "${2}"
 
-- match: "truenas.*.mem.*.*"
+- match: 'truenas\.(.*)\.mem\.(.*)\.(.*)'
+  match_type: "regex"
   name: "memory_${2}"
   labels:
     job: "truenas"
     instance: "${1}"
     kind: "${3}"
 
-- match: "truenas.*.system.swap.*"
+- match: 'truenas\.(.*)\.system\.swap\.(.*)'
+  match_type: "regex"
   name: "swap"
   labels:
     job: "truenas"
@@ -29,14 +32,16 @@ mappings:
 # disk smart metrics
 ################################################
 
-- match: "truenas.*.smart.log.smart.disktemp.*.*"
+- match: 'truenas\.(.*)\.smart\.log\.smart\.disktemp\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_temperature"
   labels:
     job: "truenas"
     instance: "${1}"
     serial: "${2}"
 
-- match: "truenas.*.smart_log_smart.disktemp.*.*"
+- match: 'truenas\.(.*)\.smart_log_smart\.disktemp\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_temperature"
   labels:
     job: "truenas"
@@ -47,7 +52,8 @@ mappings:
 # disk operation mappings
 ################################################
 
-- match: "truenas.*.disk.*.*"
+- match: 'truenas\.(.*)\.disk\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_io"
   labels:
     job: "truenas"
@@ -55,7 +61,8 @@ mappings:
     disk: "${2}"
     op: "${3}"
 
-- match: "truenas.*.disk_ops.*.*"
+- match: 'truenas\.(.*)\.disk_ops\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_io_ops"
   labels:
     job: "truenas"
@@ -63,7 +70,8 @@ mappings:
     disk: "${2}"
     op: "${3}"
 
-- match: "truenas.*.disk_ext.*.*"
+- match: 'truenas\.(.*)\.disk_ext\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_io"
   labels:
     job: "truenas"
@@ -71,7 +79,8 @@ mappings:
     disk: "${2}"
     op: "${3}"
 
-- match: "truenas.*.disk_ext_ops.*.*"
+- match: 'truenas\.(.*)\.disk_ext_ops\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_io_ops"
   labels:
     job: "truenas"
@@ -79,28 +88,32 @@ mappings:
     disk: "${2}"
     op: "${3}"
 
-- match: "truenas.*.disk_backlog.*.backlog"
+- match: 'truenas\.(.*)\.disk_backlog\.(.*)\.backlog'
+  match_type: "regex"
   name: "disk_io_backlog"
   labels:
     job: "truenas"
     instance: "${1}"
     disk: "${2}"
 
-- match: "truenas.*.disk_busy.*.busy"
+- match: 'truenas\.(.*)\.disk_busy\.(.*)\.busy'
+  match_type: "regex"
   name: "disk_busy"
   labels:
     job: "truenas"
     instance: "${1}"
     disk: "${2}"
 
-- match: "truenas.*.disk_util.*.utilization"
+- match: 'truenas\.(.*)\.disk_util\.(.*)\.utilization'
+  match_type: "regex"
   name: "disk_utilization"
   labels:
     job: "truenas"
     instance: "${1}"
     disk: "${2}"
 
-- match: "truenas.*.disk_mops.*.*"
+- match: 'truenas\.(.*)\.disk_mops\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_io"
   labels:
     job: "truenas"
@@ -108,7 +121,8 @@ mappings:
     disk: "${2}"
     op: "merged_${3}"
 
-- match: "truenas.*.disk_ext_mops.*.*"
+- match: 'truenas\.(.*)\.disk_ext_mops\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_io"
   labels:
     job: "truenas"
@@ -116,7 +130,8 @@ mappings:
     disk: "${2}"
     op: "merged_${3}"
 
-- match: "truenas.*.disk_iotime.*.*"
+- match: 'truenas\.(.*)\.disk_iotime\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_iotime"
   labels:
     job: "truenas"
@@ -124,7 +139,8 @@ mappings:
     disk: "${2}"
     op: "${3}"
 
-- match: "truenas.*.disk_ext_iotime.*.*"
+- match: 'truenas\.(.*)\.disk_ext_iotime\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_iotime"
   labels:
     job: "truenas"
@@ -132,14 +148,16 @@ mappings:
     disk: "${2}"
     op: "${3}"
 
-- match: "truenas.*.disk_qops.*.operations"
+- match: 'truenas\.(.*)\.disk_qops\.(.*)\.operations'
+  match_type: "regex"
   name: "disk_qops"
   labels:
     job: "truenas"
     instance: "${1}"
     disk: "${2}"
 
-- match: "truenas.*.disk_await.*.*"
+- match: 'truenas\.(.*)\.disk_await\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_await"
   labels:
     job: "truenas"
@@ -147,7 +165,8 @@ mappings:
     disk: "${2}"
     op: "${3}"
 
-- match: "truenas.*.disk_ext_await.*.*"
+- match: 'truenas\.(.*)\.disk_ext_await\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_await"
   labels:
     job: "truenas"
@@ -155,7 +174,8 @@ mappings:
     disk: "${2}"
     op: "${3}"
 
-- match: "truenas.*.disk_avgsz.*.*"
+- match: 'truenas\.(.*)\.disk_avgsz\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_io_size"
   labels:
     job: "truenas"
@@ -163,7 +183,8 @@ mappings:
     disk: "${2}"
     op: "${3}"
 
-- match: "truenas.*.disk_ext_avgsz.*.*"
+- match: 'truenas\.(.*)\.disk_ext_avgsz\.(.*)\.(.*)'
+  match_type: "regex"
   name: "disk_io_size"
   labels:
     job: "truenas"
@@ -171,14 +192,16 @@ mappings:
     disk: "${2}"
     op: "${3}"
 
-- match: "truenas.*.disk_svctm.*.svctm"
+- match: 'truenas\.(.*)\.disk_svctm\.(.*)\.svctm'
+  match_type: "regex"
   name: "disk_svctm"
   labels:
     job: "truenas"
     instance: "${1}"
     disk: "${2}"
 
-- match: "truenas.*.system.io.*"
+- match: 'truenas\.(.*)\.system\.io\.(.*)'
+  match_type: "regex"
   name: "system_io"
   labels:
     job: "truenas"
@@ -189,55 +212,63 @@ mappings:
 # CPU mapping
 ################################################
 
-- match: "truenas.*.system.intr.interrupts"
+- match: 'truenas\.(.*)\.system\.intr\.interrupts'
+  match_type: "regex"
   name: "interrupts"
   labels:
     job: "truenas"
     instance: "${1}"
     kind: "hard"
 
-- match: "truenas.*.system.cpu.softirq"
+- match: 'truenas\.(.*)\.system\.cpu\.softirq'
+  match_type: "regex"
   name: "interrupts"
   labels:
     job: "truenas"
     instance: "${1}"
     kind: "soft"
 
-- match: "truenas.*.cpu.*.softirq"
+- match: 'truenas\.(.*)\.cpu\.(.*)\.softirq'
+  match_type: "regex"
   name: "cpu_softirq"
   labels:
     job: "truenas"
     instance: "${1}"
     cpu: "${2}"
 
-- match: "truenas.*.system.ctxt.switches"
+- match: 'truenas\.(.*)\.system\.ctxt\.switches'
+  match_type: "regex"
   name: "context_switches"
   labels:
     job: "truenas"
     instance: "${1}"
 
-- match: "truenas.*.system.cpu.*"
+- match: 'truenas\.(.*)\.system\.cpu\.(.*)'
+  match_type: "regex"
   name: "cpu_total"
   labels:
     job: "truenas"
     instance: "${1}"
     kind: "${2}"
 
-- match: "truenas.*.cputemp.temperatures.*"
+- match: 'truenas\.(.*)\.cputemp\.temperatures\.(.*)'
+  match_type: "regex"
   name: "cpu_temperature"
   labels:
     job: "truenas"
     instance: "${1}"
     cpu: "cpu${2}"
 
-- match: "truenas.*.cpu.core_throttling.*"
+- match: 'truenas\.(.*)\.cpu\.core_throttling\.(.*)'
+  match_type: "regex"
   name: "cpu_throttling"
   labels:
     job: "truenas"
     instance: "${1}"
     cpu: "${2}"
 
-- match: "truenas.*.cpu.cpufreq.*"
+- match: 'truenas\.(.*)\.cpu\.cpufreq\.(.*)'
+  match_type: "regex"
   name: "cpu_frequency"
   labels:
     job: "truenas"
@@ -266,20 +297,23 @@ mappings:
 # process mapping
 ################################################
 
-- match: "truenas.*.system.forks.started"
+- match: 'truenas\.(.*)\.system\.forks\.started'
+  match_type: "regex"
   name: "processes_forks"
   labels:
     job: "truenas"
     instance: "${1}"
 
-- match: "truenas.*.system.processes.*"
+- match: 'truenas\.(.*)\.system\.processes\.(.*)'
+  match_type: "regex"
   name: "processes"
   labels:
     job: "truenas"
     instance: "${1}"
     kind: "${2}"
 
-- match: "truenas.*.system.active_processes.*"
+- match: 'truenas\.(.*)\.system\.active_processes\.(.*)'
+  match_type: "regex"
   name: "processes"
   labels:
     job: "truenas"
@@ -290,26 +324,30 @@ mappings:
 # uptime mapping
 ################################################
 
-- match: "truenas.*.system.uptime.uptime"
+- match: 'truenas\.(.*)\.system\.uptime\.uptime'
+  match_type: "regex"
   name: "uptime"
   labels:
     job: "truenas"
     instance: "${1}"
 
-- match: "truenas.*.system.clock_sync_state.state"
+- match: 'truenas\.(.*)\.system\.clock_sync_state\.state'
+  match_type: "regex"
   name: "clock_synced"
   labels:
     job: "truenas"
     instance: "${1}"
 
-- match: "truenas.*.system.clock_status.*"
+- match: 'truenas\.(.*)\.system\.clock_status\.(.*)'
+  match_type: "regex"
   name: "clock_status"
   labels:
     job: "truenas"
     instance: "${1}"
     state: "${2}"
 
-- match: "truenas.*.system.clock_sync_offset.offset"
+- match: 'truenas\.(.*)\.system\.clock_sync_offset\.offset'
+  match_type: "regex"
   name: "clock_offset"
   labels:
     job: "truenas"
@@ -319,7 +357,8 @@ mappings:
 # load mapping
 ################################################
 
-- match: "truenas.*.system.load.*"
+- match: 'truenas\.(.*)\.system\.load\.(.*)'
+  match_type: "regex"
   name: "system_load"
   labels:
     job: "truenas"
@@ -330,7 +369,8 @@ mappings:
 # nsfd mappings
 ################################################
 
-- match: "truenas.*.nfsd.*.*"
+- match: 'truenas\.(.*)\.nfsd\.(.*)\.(.*)'
+  match_type: "regex"
   name: "nfs_${2}"
   labels:
     job: "truenas"
@@ -341,7 +381,8 @@ mappings:
 # zfs mappings
 ################################################
 
-- match: "truenas.*.zfs.*.*"
+- match: 'truenas\.(.*)\.zfs\.(.*)\.(.*)'
+  match_type: "regex"
   name: "zfs_${2}"
   labels:
     job: "truenas"
@@ -361,7 +402,8 @@ mappings:
 # network mappings
 ################################################
 
-- match: "truenas.*.net.*.*"
+- match: 'truenas\.(.*)\.net\.(.*)\.(.*)'
+  match_type: "regex"
   name: "interface_io"
   labels:
     job: "truenas"
@@ -369,14 +411,16 @@ mappings:
     interface: "${2}"
     op: "${3}"
 
-- match: "truenas.*.net_speed.*.speed"
+- match: 'truenas\.(.*)\.net_speed\.(.*)\.speed'
+  match_type: "regex"
   name: "interface_speed"
   labels:
     job: "truenas"
     instance: "${1}"
     interface: "${2}"
 
-- match: "truenas.*.net_duplex.*.*"
+- match: 'truenas\.(.*)\.net_duplex\.(.*)\.(.*)'
+  match_type: "regex"
   name: "interface_duplex"
   labels:
     job: "truenas"
@@ -384,7 +428,8 @@ mappings:
     interface: "${2}"
     state: "${3}"
 
-- match: "truenas.*.net_operstate.*.*"
+- match: 'truenas\.(.*)\.net_operstate\.(.*)\.(.*)'
+  match_type: "regex"
   name: "interface_operationstate"
   labels:
     job: "truenas"
@@ -392,7 +437,8 @@ mappings:
     interface: "${2}"
     state: "${3}"
 
-- match: "truenas.*.net_carrier.*.*"
+- match: 'truenas\.(.*)\.net_carrier\.(.*)\.(.*)'
+  match_type: "regex"
   name: "interface_carrierstate"
   labels:
     job: "truenas"
@@ -400,14 +446,16 @@ mappings:
     interface: "${2}"
     state: "${3}"
 
-- match: "truenas.*.net_mtu.*.mtu"
+- match: 'truenas\.(.*)\.net_mtu\.(.*)\.mtu'
+  match_type: "regex"
   name: "interface_mtu"
   labels:
     job: "truenas"
     instance: "${1}"
     interface: "${2}"
 
-- match: "truenas.*.net_packets.*.*"
+- match: 'truenas\.(.*)\.net_packets\.(.*)\.(.*)'
+  match_type: "regex"
   name: "interface_packets"
   labels:
     job: "truenas"
@@ -415,7 +463,8 @@ mappings:
     interface: "${2}"
     op: "${3}"
 
-- match: "truenas.*.net_errors.*.*"
+- match: 'truenas\.(.*)\.net_errors\.(.*)\.(.*)'
+  match_type: "regex"
   name: "interface_errors"
   labels:
     job: "truenas"
@@ -423,7 +472,8 @@ mappings:
     interface: "${2}"
     op: "${3}"
 
-- match: "truenas.*.net_drops.*.*"
+- match: 'truenas\.(.*)\.net_drops\.(.*)\.(.*)'
+  match_type: "regex"
   name: "interface_drops"
   labels:
     job: "truenas"
@@ -431,7 +481,8 @@ mappings:
     interface: "${2}"
     op: "${3}"
 
-- match: "truenas.*.system.net.*"
+- match: 'truenas\.(.*)\.system\.net\.(.*)'
+  match_type: "regex"
   name: "system_net_io"
   labels:
     job: "truenas"


### PR DESCRIPTION
`cpu_idlestate`, `cpu_usage` and `zfs_pool` accept hostname that includes dots. However, other metrics does not accept it. Therefore, this PR fix all patterns to use regex same like `cpu_idlestate` etc.

Before
```
truenas_nas_example_com_cputemp_temperatures_0 28.45
```

After
```
cpu_temperature{cpu="cpu0",instance="nas.example.com",job="truenas"} 28.3666667
```