### PR TITLE
Simplify `graphite_mapping.conf`

### DIFF
--- a/graphite_mapping.conf
+++ b/graphite_mapping.conf
@@ -4,487 +4,433 @@ mappings:
 # memory mapping
 ################################################
 
-- match: 'truenas\.(.*)\.system\.ram\.(.*)'
-  match_type: "regex"
-  name: "physical_memory"
+- match: truenas.*.system.ram.*
+  name: physical_memory_${2}
   labels:
-    job: "truenas"
-    instance: "${1}"
-    kind: "${2}"
+    job: truenas
+    instance: $1
+    kind: $2
 
-- match: 'truenas\.(.*)\.mem\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "memory_${2}"
+- match: truenas.*.mem.*.*
+  name: memory_$2
   labels:
-    job: "truenas"
-    instance: "${1}"
-    kind: "${3}"
+    job: truenas
+    instance: $1
+    kind: $3
 
-- match: 'truenas\.(.*)\.system\.swap\.(.*)'
-  match_type: "regex"
-  name: "swap"
+- match: truenas.*.system.swap.*
+  name: swap
   labels:
-    job: "truenas"
-    instance: "${1}"
-    kind: "${2}"
+    job: truenas
+    instance: $1
+    kind: $2
 
 ################################################
 # disk smart metrics
 ################################################
 
-- match: 'truenas\.(.*)\.smart\.log\.smart\.disktemp\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_temperature"
+- match: truenas.*.smart.log.smart.disktemp.*.*
+  name: disk_temperature
   labels:
-    job: "truenas"
-    instance: "${1}"
-    serial: "${2}"
+    job: truenas
+    instance: $1
+    serial: $2
 
-- match: 'truenas\.(.*)\.smart_log_smart\.disktemp\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_temperature"
+- match: truenas.*.smart_log_smart.disktemp.*.*
+  name: disk_temperature
   labels:
-    job: "truenas"
-    instance: "${1}"
-    serial: "${2}"
+    job: truenas
+    instance: $1
+    serial: $2
 
 ################################################
 # disk operation mappings
 ################################################
 
-- match: 'truenas\.(.*)\.disk\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_io"
+- match: truenas.*.disk.*.*
+  name: disk_io
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.disk_ops\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_io_ops"
+- match: truenas.*.disk_ops.*.*
+  name: disk_io_ops
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.disk_ext\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_io"
+- match: truenas.*.disk_ext.*.*
+  name: disk_io
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.disk_ext_ops\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_io_ops"
+- match: truenas.*.disk_ext_ops.*.*
+  name: disk_io_ops
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.disk_backlog\.(.*)\.backlog'
-  match_type: "regex"
-  name: "disk_io_backlog"
+- match: truenas.*.disk_backlog.*.backlog
+  name: disk_io_backlog
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
+    job: truenas
+    instance: $1
+    disk: $2
 
-- match: 'truenas\.(.*)\.disk_busy\.(.*)\.busy'
-  match_type: "regex"
-  name: "disk_busy"
+- match: truenas.*.disk_busy.*.busy
+  name: disk_busy
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
+    job: truenas
+    instance: $1
+    disk: $2
 
-- match: 'truenas\.(.*)\.disk_util\.(.*)\.utilization'
-  match_type: "regex"
-  name: "disk_utilization"
+- match: truenas.*.disk_util.*.utilization
+  name: disk_utilization
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
+    job: truenas
+    instance: $1
+    disk: $2
 
-- match: 'truenas\.(.*)\.disk_mops\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_io"
+- match: truenas.*.disk_mops.*.*
+  name: disk_io
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "merged_${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: merged_$3
 
-- match: 'truenas\.(.*)\.disk_ext_mops\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_io"
+- match: truenas.*.disk_ext_mops.*.*
+  name: disk_io
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "merged_${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: merged_$3
 
-- match: 'truenas\.(.*)\.disk_iotime\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_iotime"
+- match: truenas.*.disk_iotime.*.*
+  name: disk_iotime
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.disk_ext_iotime\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_iotime"
+- match: truenas.*.disk_ext_iotime.*.*
+  name: disk_iotime
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.disk_qops\.(.*)\.operations'
-  match_type: "regex"
-  name: "disk_qops"
+- match: truenas.*.disk_qops.*.operations
+  name: disk_qops
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
+    job: truenas
+    instance: $1
+    disk: $2
 
-- match: 'truenas\.(.*)\.disk_await\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_await"
+- match: truenas.*.disk_await.*.*
+  name: disk_await
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.disk_ext_await\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_await"
+- match: truenas.*.disk_ext_await.*.*
+  name: disk_await
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.disk_avgsz\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_io_size"
+- match: truenas.*.disk_avgsz.*.*
+  name: disk_io_size
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.disk_ext_avgsz\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "disk_io_size"
+- match: truenas.*.disk_ext_avgsz.*.*
+  name: disk_io_size
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    disk: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.disk_svctm\.(.*)\.svctm'
-  match_type: "regex"
-  name: "disk_svctm"
+- match: truenas.*.disk_svctm.*.svctm
+  name: disk_svctm
   labels:
-    job: "truenas"
-    instance: "${1}"
-    disk: "${2}"
+    job: truenas
+    instance: $1
+    disk: $2
 
-- match: 'truenas\.(.*)\.system\.io\.(.*)'
-  match_type: "regex"
-  name: "system_io"
+- match: truenas.*.system.io.*
+  name: system_io
   labels:
-    job: "truenas"
-    instance: "${1}"
-    op: "${2}"
+    job: truenas
+    instance: $1
+    op: $2
 
 ################################################
 # CPU mapping
 ################################################
 
-- match: 'truenas\.(.*)\.system\.intr\.interrupts'
-  match_type: "regex"
-  name: "interrupts"
+- match: truenas.*.system.intr.interrupts
+  name: interrupts
   labels:
-    job: "truenas"
-    instance: "${1}"
-    kind: "hard"
+    job: truenas
+    instance: $1
+    kind: hard
 
-- match: 'truenas\.(.*)\.system\.cpu\.softirq'
-  match_type: "regex"
-  name: "interrupts"
+- match: truenas.*.system.cpu.softirq
+  name: interrupts
   labels:
-    job: "truenas"
-    instance: "${1}"
-    kind: "soft"
+    job: truenas
+    instance: $1
+    kind: soft
 
-- match: 'truenas\.(.*)\.cpu\.(.*)\.softirq'
-  match_type: "regex"
-  name: "cpu_softirq"
+- match: truenas.*.cpu.*.softirq
+  name: cpu_softirq
   labels:
-    job: "truenas"
-    instance: "${1}"
-    cpu: "${2}"
+    job: truenas
+    instance: $1
+    cpu: $2
 
-- match: 'truenas\.(.*)\.system\.ctxt\.switches'
-  match_type: "regex"
-  name: "context_switches"
+- match: truenas.*.system.ctxt.switches
+  name: context_switches
   labels:
-    job: "truenas"
-    instance: "${1}"
+    job: truenas
+    instance: $1
 
-- match: 'truenas\.(.*)\.system\.cpu\.(.*)'
-  match_type: "regex"
-  name: "cpu_total"
+- match: truenas.*.system.cpu.*
+  name: cpu_total
   labels:
-    job: "truenas"
-    instance: "${1}"
-    kind: "${2}"
+    job: truenas
+    instance: $1
+    kind: $2
 
-- match: 'truenas\.(.*)\.cputemp\.temperatures\.(.*)'
-  match_type: "regex"
-  name: "cpu_temperature"
+- match: truenas.*.cputemp.temperatures.*
+  name: cpu_temperature
   labels:
-    job: "truenas"
-    instance: "${1}"
-    cpu: "cpu${2}"
+    job: truenas
+    instance: $1
+    cpu: cpu$2
 
-- match: 'truenas\.(.*)\.cpu\.core_throttling\.(.*)'
-  match_type: "regex"
-  name: "cpu_throttling"
+- match: truenas.*.cpu.core_throttling.*
+  name: cpu_throttling
   labels:
-    job: "truenas"
-    instance: "${1}"
-    cpu: "${2}"
+    job: truenas
+    instance: $1
+    cpu: $2
 
-- match: 'truenas\.(.*)\.cpu\.cpufreq\.(.*)'
-  match_type: "regex"
-  name: "cpu_frequency"
+- match: truenas.*.cpu.cpufreq.*
+  name: cpu_frequency
   labels:
-    job: "truenas"
-    instance: "${1}"
-    cpu: "${2}"
+    job: truenas
+    instance: $1
+    cpu: $2
 
-- match: 'truenas\.(.*)\.cpu\.(.*)_cpuidle\.(.*)'
-  match_type: "regex"
-  name: "cpu_idlestate"
+- match: truenas.*.cpu.*.cpuidle.*
+  name: cpu_idlestate
   labels:
-    job: "truenas"
-    instance: "${1}"
-    cpu: "${2}"
-    state: "${3}"
+    job: truenas
+    instance: $1
+    cpu: $2
+    state: $3
 
-- match: 'truenas\.(.*)\.cpu\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "cpu_usage"
+- match: truenas.*.cpu.*.*
+  name: cpu_usage
   labels:
-    job: "truenas"
-    instance: "${1}"
-    cpu: "${2}"
-    kind: "${3}"
+    job: truenas
+    instance: $1
+    cpu: $2
+    kind: $3
 
 ################################################
 # process mapping
 ################################################
 
-- match: 'truenas\.(.*)\.system\.forks\.started'
-  match_type: "regex"
-  name: "processes_forks"
+- match: truenas.*.system.forks.started
+  name: processes_forks
   labels:
-    job: "truenas"
-    instance: "${1}"
+    job: truenas
+    instance: $1
 
-- match: 'truenas\.(.*)\.system\.processes\.(.*)'
-  match_type: "regex"
-  name: "processes"
+- match: truenas.*.system.processes.*
+  name: processes
   labels:
-    job: "truenas"
-    instance: "${1}"
-    kind: "${2}"
+    job: truenas
+    instance: $1
+    kind: $2
 
-- match: 'truenas\.(.*)\.system\.active_processes\.(.*)'
-  match_type: "regex"
-  name: "processes"
+- match: truenas.*.system.active_processes.*
+  name: processes
   labels:
-    job: "truenas"
-    instance: "${1}"
-    kind: "${2}"
+    job: truenas
+    instance: $1
+    kind: $2
 
 ################################################
 # uptime mapping
 ################################################
 
-- match: 'truenas\.(.*)\.system\.uptime\.uptime'
-  match_type: "regex"
-  name: "uptime"
+- match: truenas.*.system.uptime.uptime
+  name: uptime
   labels:
-    job: "truenas"
-    instance: "${1}"
+    job: truenas
+    instance: $1
 
-- match: 'truenas\.(.*)\.system\.clock_sync_state\.state'
-  match_type: "regex"
-  name: "clock_synced"
+- match: truenas.*.system.clock_sync_state.state
+  name: clock_synced
   labels:
-    job: "truenas"
-    instance: "${1}"
+    job: truenas
+    instance: $1
 
-- match: 'truenas\.(.*)\.system\.clock_status\.(.*)'
-  match_type: "regex"
-  name: "clock_status"
+- match: truenas.*.system.clock_status.*
+  name: clock_status
   labels:
-    job: "truenas"
-    instance: "${1}"
-    state: "${2}"
+    job: truenas
+    instance: $1
+    state: $2
 
-- match: 'truenas\.(.*)\.system\.clock_sync_offset\.offset'
-  match_type: "regex"
-  name: "clock_offset"
+- match: truenas.*.system.clock_sync_offset.offset
+  name: clock_offset
   labels:
-    job: "truenas"
-    instance: "${1}"
+    job: truenas
+    instance: $1
 
 ################################################
 # load mapping
 ################################################
 
-- match: 'truenas\.(.*)\.system\.load\.(.*)'
-  match_type: "regex"
-  name: "system_load"
+- match: truenas.*.system.load.*
+  name: system_load
   labels:
-    job: "truenas"
-    instance: "${1}"
-    kind: "${2}"
+    job: truenas
+    instance: $1
+    kind: $2
 
 ################################################
 # nsfd mappings
 ################################################
 
-- match: 'truenas\.(.*)\.nfsd\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "nfs_${2}"
+- match: truenas.*.nfsd.*.*
+  name: nfs_$2
   labels:
-    job: "truenas"
-    instance: "${1}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    op: $3
 
 ################################################
 # zfs mappings
 ################################################
 
-- match: 'truenas\.(.*)\.zfs\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "zfs_${2}"
+- match: truenas.*.zfs.*.*
+  name: zfs_$2
   labels:
-    job: "truenas"
-    instance: "${1}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    op: $3
 
-- match: 'truenas\.(.*)\.zfspool\.state_(.*)\.(.*)'
-  match_type: "regex"
-  name: "zfs_pool"
+- match: truenas.*.zfspool.state.*.*
+  name: zfs_pool
   labels:
-    job: "truenas"
-    instance: "${1}"
-    pool: "${2}"
-    state: "${3}"
+    job: truenas
+    instance: $1
+    pool: $2
+    state: $3
 
 ################################################
 # network mappings
 ################################################
 
-- match: 'truenas\.(.*)\.net\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "interface_io"
+- match: truenas.*.net.*.*
+  name: interface_io
   labels:
-    job: "truenas"
-    instance: "${1}"
-    interface: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    interface: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.net_speed\.(.*)\.speed'
-  match_type: "regex"
-  name: "interface_speed"
+- match: truenas.*.net_speed.*.speed
+  name: interface_speed
   labels:
-    job: "truenas"
-    instance: "${1}"
-    interface: "${2}"
+    job: truenas
+    instance: $1
+    interface: $2
 
-- match: 'truenas\.(.*)\.net_duplex\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "interface_duplex"
+- match: truenas.*.net_duplex.*.*
+  name: interface_duplex
   labels:
-    job: "truenas"
-    instance: "${1}"
-    interface: "${2}"
-    state: "${3}"
+    job: truenas
+    instance: $1
+    interface: $2
+    state: $3
 
-- match: 'truenas\.(.*)\.net_operstate\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "interface_operationstate"
+- match: truenas.*.net_operstate.*.*
+  name: interface_operationstate
   labels:
-    job: "truenas"
-    instance: "${1}"
-    interface: "${2}"
-    state: "${3}"
+    job: truenas
+    instance: $1
+    interface: $2
+    state: $3
 
-- match: 'truenas\.(.*)\.net_carrier\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "interface_carrierstate"
+- match: truenas.*.net_carrier.*.*
+  name: interface_carrierstate
   labels:
-    job: "truenas"
-    instance: "${1}"
-    interface: "${2}"
-    state: "${3}"
+    job: truenas
+    instance: $1
+    interface: $2
+    state: $3
 
-- match: 'truenas\.(.*)\.net_mtu\.(.*)\.mtu'
-  match_type: "regex"
-  name: "interface_mtu"
+- match: truenas.*.net_mtu.*.mtu
+  name: interface_mtu
   labels:
-    job: "truenas"
-    instance: "${1}"
-    interface: "${2}"
+    job: truenas
+    instance: $1
+    interface: $2
 
-- match: 'truenas\.(.*)\.net_packets\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "interface_packets"
+- match: truenas.*.net_packets.*.*
+  name: interface_packets
   labels:
-    job: "truenas"
-    instance: "${1}"
-    interface: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    interface: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.net_errors\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "interface_errors"
+- match: truenas.*.net_errors.*.*
+  name: interface_errors
   labels:
-    job: "truenas"
-    instance: "${1}"
-    interface: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    interface: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.net_drops\.(.*)\.(.*)'
-  match_type: "regex"
-  name: "interface_drops"
+- match: truenas.*.net_drops.*.*
+  name: interface_drops
   labels:
-    job: "truenas"
-    instance: "${1}"
-    interface: "${2}"
-    op: "${3}"
+    job: truenas
+    instance: $1
+    interface: $2
+    op: $3
 
-- match: 'truenas\.(.*)\.system\.net\.(.*)'
-  match_type: "regex"
-  name: "system_net_io"
+- match: truenas.*.system.net.*
+  name: system_net_io
   labels:
-    job: "truenas"
-    instance: "${1}"
-    op: "${2}"
+    job: truenas
+    instance: $1
+    op: $2

--- a/graphite_mapping.conf
+++ b/graphite_mapping.conf
@@ -5,7 +5,7 @@ mappings:
 ################################################
 
 - match: truenas.*.system.ram.*
-  name: physical_memory_${2}
+  name: physical_memory_$2
   labels:
     job: truenas
     instance: $1
@@ -244,21 +244,23 @@ mappings:
     instance: $1
     cpu: $2
 
-- match: truenas.*.cpu.*.cpuidle.*
+- match: 'truenas\.(.*)\.cpu\.(cpu\d+)_cpuidle\.(.*)$'
+  match_type: regex
   name: cpu_idlestate
   labels:
     job: truenas
-    instance: $1
-    cpu: $2
-    state: $3
+    instance: '${1}'
+    cpu: '${2}'
+    state: '${3}'
 
-- match: truenas.*.cpu.*.*
+- match: 'truenas\.(.*)\.cpu\.(cpu\d+)\.(.*)$'
+  match_type: regex
   name: cpu_usage
   labels:
     job: truenas
-    instance: $1
-    cpu: $2
-    kind: $3
+    instance: '${1}'
+    cpu: '${2}'
+    kind: '${3}'
 
 ################################################
 # process mapping
@@ -346,13 +348,14 @@ mappings:
     instance: $1
     op: $3
 
-- match: truenas.*.zfspool.state.*.*
+- match: 'truenas\.(.*)\.zfspool\.state_(.*)\.(.*)$'
+  match_type: regex
   name: zfs_pool
   labels:
     job: truenas
-    instance: $1
-    pool: $2
-    state: $3
+    instance: '${1}'
+    pool: '${2}'
+    state: '${3}'
 
 ################################################
 # network mappings

--- a/graphite_mapping.conf
+++ b/graphite_mapping.conf
@@ -249,18 +249,18 @@ mappings:
   name: cpu_idlestate
   labels:
     job: truenas
-    instance: '${1}'
-    cpu: '${2}'
-    state: '${3}'
+    instance: $1
+    cpu: $2
+    state: $3
 
 - match: 'truenas\.(.*)\.cpu\.(cpu\d+)\.(.*)$'
   match_type: regex
   name: cpu_usage
   labels:
     job: truenas
-    instance: '${1}'
-    cpu: '${2}'
-    kind: '${3}'
+    instance: $1
+    cpu: $2
+    kind: $3
 
 ################################################
 # process mapping
@@ -353,9 +353,9 @@ mappings:
   name: zfs_pool
   labels:
     job: truenas
-    instance: '${1}'
-    pool: '${2}'
-    state: '${3}'
+    instance: $1
+    pool: $2
+    state: $3
 
 ################################################
 # network mappings


### PR DESCRIPTION
This PR updates the Graphite mappings for TrueNAS metrics to simplify the syntax and ensure compatibility with TrueNAS 24.04 (Dragonfish). The main changes are:

1. Replaced regex syntax with simpler wildcard syntax using asterisks (*).
2. Removed explicit "match_type: regex" declarations where possible.
3. Changed capturing group syntax from ${n} to $n for consistency and simplicity.


These changes maintain the overall structure and intent of the mappings while making them more readable and easier to maintain. The updated mappings should work correctly with TrueNAS 24.04 (Dragonfish) and provide consistent metric collection.

I will update the README too, because the new setup requires a `Namespace` field and some other fields have changed too.