### PR TITLE
fix: TruenasScale Dashboard - Inlude All for instance 

### DIFF
--- a/dashboards/truenas_scale.json
+++ b/dashboards/truenas_scale.json
@@ -5974,7 +5974,7 @@
           "uid": "${DS_MIMIR}"
         },
         "definition": "label_values(uptime{job=\"$job\"},instance)",
-        "includeAll": false,
+        "includeAll": true,
         "name": "instance",
         "options": [],
         "query": {

--- a/dashboards/truenas_scale.json
+++ b/dashboards/truenas_scale.json
@@ -6076,6 +6076,6 @@
   "timezone": "cet",
   "title": "TrueNAS Scale / Overview",
   "uid": "truenas-overview",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }


### PR DESCRIPTION
Enable include all selection so you can see the dashboard with all instances:
<img width="298" height="298" alt="image" src="https://github.com/user-attachments/assets/8003924d-17b7-4bde-a45c-0d3601c3a3f7" />
